### PR TITLE
added fix to prevent Bulma from breaking PrismJS codeblock highlighting

### DIFF
--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -18,3 +18,20 @@
 // code {
 //     font-family: "Source Code Pro", monospace;
 // }
+
+// overrides to fix Bulma from breaking PrismJS code highlighting if you
+// use numbers or tags within a code block.
+.content .tag,
+.content .number {
+    display: inline;
+    padding: inherit;
+    font-size: inherit;
+    line-height: inherit;
+    text-align: inherit;
+    vertical-align: inherit;
+    border-radius: inherit;
+    font-weight: inherit;
+    white-space: inherit;
+    background: inherit;
+    margin: inherit;
+}


### PR DESCRIPTION
Added a fix to prevent Bulma's default CSS from breaking PrismJS markdown highlighting of code blocks.

 
![gatsby-website-start-pr](https://user-images.githubusercontent.com/42158990/80648629-599b6280-8a25-11ea-9079-1bc1f2bd14a2.png)
