### PR TITLE
Fix some PurgeCSS glitches.

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -97,7 +97,16 @@ module.exports = {
             resolve: `gatsby-plugin-purgecss`,
             options: {
                 printRejected: true,
-                whitelist: ["blockquote"],
+                whitelist: [
+                    "blockquote",
+                    "table",
+                    "th",
+                    "tr",
+                    "td",
+                    "tbody",
+                    "thead",
+                    "content",
+                ],
                 whitelistPatternsChildren: [/^token/, /^pre/, /^code/],
                 // develop: true, // Enable while using `gatsby develop`
             },


### PR DESCRIPTION
PurgeCSS probably can't read the Markdown files, so it's doing things
like ripping out the table CSS even when blog posts have tables.